### PR TITLE
Include UART configuration in stdout-path

### DIFF
--- a/arch/arm/dts/rk3328-rock64.dts
+++ b/arch/arm/dts/rk3328-rock64.dts
@@ -13,7 +13,7 @@
 	compatible = "pine64,rock64", "rockchip,rk3328";
 
 	chosen {
-		stdout-path = &uart2;
+		stdout-path = "serial2:1500000n8";
 	};
 
 	aliases {

--- a/arch/arm/dts/rk3399-rockpro64.dts
+++ b/arch/arm/dts/rk3399-rockpro64.dts
@@ -14,7 +14,7 @@
 	compatible = "pine64,rockpro64", "rockchip,rk3399";
 
 	chosen {
-		stdout-path = &uart2;
+		stdout-path = "serial2:1500000n8";
 	};
 
 	aliases {


### PR DESCRIPTION
The OpenBSD kernel configures the speed of the serial console based on the stdout-path
property. Since rock64 and rockpro64 use a nonstandard serial speed it is important to
specify the speed in the stdout-path property such that the kernel doesn't switch the
serial console to 115200n8 and users don't wonder why there is no serial output.