### PR TITLE
RFC RockPro64 DTS change pmic_int_l pinctrl

### DIFF
--- a/arch/arm/dts/rk3399-rockpro64.dts
+++ b/arch/arm/dts/rk3399-rockpro64.dts
@@ -446,7 +446,7 @@
 
 	pmic {
 		pmic_int_l: pmic-int-l {
-			rockchip,pins = <1 RK_PC5 RK_FUNC_GPIO &pcfg_pull_up>;
+			rockchip,pins = <3 RK_PB2 RK_FUNC_GPIO &pcfg_pull_up>;
 		};
 	};
 


### PR DESCRIPTION
I was checking the pins against the schematic, on the Rockchip-master I happened across pmic_int_l, it's listed as Bank 1 C5, but that is I2C8_SCL, which is supposedly the I2C broken out on the 40-pin header.  I saw on the schematic next to GPIO3 B2:  "Note:PMU 终断 GPIO1_C5 更改至此"

I don't read Chinese so machine translation resulted in: "Note: PMU Final break GPIO1_C5 Change to this point"